### PR TITLE
kata-check: fix tests

### DIFF
--- a/cli/kata-check_amd64_test.go
+++ b/cli/kata-check_amd64_test.go
@@ -116,7 +116,7 @@ func TestCCCheckCLIFunction(t *testing.T) {
 	// capture output this time
 	kataLog.Logger.Out = buf
 
-	fn, ok := ccCheckCLICommand.Action.(func(context *cli.Context) error)
+	fn, ok := kataCheckCLICommand.Action.(func(context *cli.Context) error)
 	assert.True(ok)
 
 	err = fn(ctx)


### PR DESCRIPTION
Fix test rename to nwe function name.

Signed-off-by: Jose Carlos Venegas Munoz <jose.carlos.venegas.munoz@intel.com>