### PR TITLE
Enforce ctx timeout for CLH's API calls and Use API in stopSandbox

### DIFF
--- a/virtcontainers/clh.go
+++ b/virtcontainers/clh.go
@@ -46,6 +46,7 @@ const (
 
 const (
 	clhTimeout            = 10
+	clhApiTimeout         = 1
 	clhSocket             = "clh.sock"
 	clhAPISocket          = "clh-api.sock"
 	clhLogFile            = "clh.log"
@@ -1090,10 +1091,10 @@ func (c *cloudHypervisor) isClhRunning(timeout int) (bool, error) {
 		return false, nil
 	}
 
-	ctx := context.Background()
 	timeStart := time.Now()
 	cl := c.client()
 	for {
+		ctx, _ := context.WithTimeout(context.Background(), clhApiTimeout*time.Second)
 		_, _, err := cl.VmmPingGet(ctx)
 		if err == nil {
 			return true, nil
@@ -1157,7 +1158,7 @@ func (c *cloudHypervisor) bootVM(timeout int) error {
 		return fmt.Errorf("Invalid timeout %ds", timeout)
 	}
 
-	ctx := context.Background()
+	ctx, _ := context.WithTimeout(context.Background(), clhApiTimeout*time.Second)
 
 	cl := c.client()
 


### PR DESCRIPTION
Two changes as a part of porting CLH's HTTP API in kata:
1. Enforce context timeout (1s) for all HTTP API calls in kata, as undefined API calls will hang forever (related [issue](https://github.com/cloud-hypervisor/cloud-hypervisor/issues/472) from CLH).
2. Use CLH's HTTP API to terminate CLH instance (instead of `kill` command). 